### PR TITLE
besser die harte Tour, also restart

### DIFF
--- a/common/ffmwu_defaults.yaml
+++ b/common/ffmwu_defaults.yaml
@@ -88,6 +88,7 @@ icvpn:
         conf: !loc_join [*TINC_DIR, 'tinc.conf']
         hosts: !loc_join [*TINC_DIR, 'hosts']
         pidfile: !loc_join ['/var/run', !str_join ['tinc.', *IC_IF, '.pid']]
+        exec: 'tinc'
         iamdb: # :)
             hinterschinken: 'wiesbaden2'
             lotuswurzel: 'wiesbaden1'

--- a/update_bird_conf_gw.py
+++ b/update_bird_conf_gw.py
@@ -49,9 +49,10 @@ def update_bird_conf():
 
             # Leider lässt sich bird nicht mittels Signalen dazu veranlassen die Konfiguration einzulesen.
             # Also wird mit ``p.m`` auf den ``service`` Befehl vom Betriebssystem drunter zurückgegriffen:
+            # ... besser doch die harte Tour (restart) ...
             p.m(
-                'reloading v%s daemon' %(v),
-                cmdd=dict(cmd='sudo service %s reload' %(s['icvpn']['bird']['ip_ver'][v]['exec']))
+                'restarting v%s daemon' %(v),
+                cmdd=dict(cmd='sudo service %s restart' %(s['icvpn']['bird']['ip_ver'][v]['exec']))
             )
 
 if __name__ == '__main__':

--- a/update_tinc_conf_gw.py
+++ b/update_tinc_conf_gw.py
@@ -71,13 +71,13 @@ def update_tinc_conf():
         # .. wird die Konfiguration danach mit der aus dem Template-Handler (``bc.write``) ersetzt (``append=False``).
         tc.write(s['icvpn']['tinc']['conf'], append=False)
 
-        # Der ``signal_handler`` liest beim Start das angegebene ``pidfile`` ein, und ermittelt so
-        # die Prozess-ID
-        tinc = p.signal_handler(s['icvpn']['tinc']['pidfile'])
-        # Letzter Schritt: dem Prozess im Signal-Handler ein ``SIGHUP`` schicken
-        # tinc liest daraufhin die Konfiguration neu ein, und passt seine Verbindungen entsprechend an..
-        # (steht zumindest so in der man-page ;)
-        tinc.hup
+        # Offenbar ist leider nur ein restart die wirklich stabile Variante,
+        # tinc zum Beachten der neuen config zu bringen _und_ überhaupt
+        # sicherzustellen, dass tinc auch läuft.
+        p.m(
+            'restarting tinc daemon',
+            cmdd=dict(cmd='sudo service %s restart' %(s['icvpn']['tinc']['exec']))
+        )
 
 if __name__ == '__main__':
     update_tinc_conf()


### PR DESCRIPTION
Hi spookey!
Ich habe mehrfach beobachtet, dass tinc auf einem der gates einfach nicht läuft. Mindestens ein Mal habe ich auch bemerkt, dass tinc auf ein HUP seine erneuerte config _nicht_ korrekt neu gezogen hat. Deshalb würde ich vorschlagen, dass wir jedes Mal, wenn sich an tinc- oder bird-config tatsächlich etwas geändert hat, den sicheren Weg gehen und das Zeug neu starten. OK?
Und schaust Du auch bitte drauf, ob ich das so dann auch richtig umgesetzt habe!?
